### PR TITLE
Theme tweaks 6 3

### DIFF
--- a/theme/about-template.php
+++ b/theme/about-template.php
@@ -1,0 +1,34 @@
+<?php 
+/*
+Template Name: Cablecast About Page
+*/
+// Start the WordPress session
+
+get_header();
+?>
+
+<section id="primary" class="p-2">
+        <main id="main">
+		
+        <h2 class="page-title text-center"><?php single_post_title(); ?></h2>
+
+        <div class="about-info-container">
+            <div class="about-description"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat.</p></div>
+            <div class="about-feature-image"><?php echo the_post_thumbnail(); ?></div>
+        </div>
+
+        <!-- put featured custom collection here? -->
+
+        <h3 class="contact-info-title">GET IN TOUCH</h3>
+        <div class="contact-info-container">
+            <div class="contact-info"><strong>Phone:</strong><p>952-223-4455</p></div>
+            <div class="contact-info"><strong>Address:</strong><p>400 South 4th Street #410,<br> Minneapolis MN 55415</p></div>
+            <div class="contact-info"><strong>Email:</strong><p>support@cablecast.tv</p></div>
+        </div>
+
+        <div class="about-page-main-content"><?php the_content(); ?></div>
+
+        </main><!-- #main -->
+    </section><!-- #primary -->
+
+<?php get_footer(); ?>

--- a/theme/about-template.php
+++ b/theme/about-template.php
@@ -13,17 +13,18 @@ get_header();
         <h2 class="page-title text-center"><?php single_post_title(); ?></h2>
 
         <div class="about-info-container">
-            <div class="about-description"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat.</p></div>
             <div class="about-feature-image"><?php echo the_post_thumbnail(); ?></div>
+            <div class="about-description"><?php the_excerpt(); ?></div>
         </div>
 
         <!-- put featured custom collection here? -->
 
         <h3 class="contact-info-title">GET IN TOUCH</h3>
         <div class="contact-info-container">
-            <div class="contact-info"><strong>Phone:</strong><p>952-223-4455</p></div>
+        <?php the_meta(); ?>
+            <!-- <div class="contact-info"><strong>Phone:</strong><p>952-223-4455</p></div>
             <div class="contact-info"><strong>Address:</strong><p>400 South 4th Street #410,<br> Minneapolis MN 55415</p></div>
-            <div class="contact-info"><strong>Email:</strong><p>support@cablecast.tv</p></div>
+            <div class="contact-info"><strong>Email:</strong><p>support@cablecast.tv</p></div> -->
         </div>
 
         <div class="about-page-main-content"><?php the_content(); ?></div>

--- a/theme/front-page.php
+++ b/theme/front-page.php
@@ -1,10 +1,7 @@
 <?php
 /**
- * The template for displaying all pages
+ * The template for displaying the front page
  *
- * This is the template that displays all pages by default. Please note that
- * this is the WordPress construct of pages: specifically, posts with a post
- * type of `page`.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
@@ -18,7 +15,7 @@ get_header();
 
     <section id="primary" class="p-2">
         <main id="main">
-		<h2 class="page-title text-center"><?php single_post_title(); ?></h2>
+		
             <?php
 
 			/* Start the Loop */

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -545,3 +545,16 @@ function my_theme_enqueue_scripts() {
     wp_enqueue_script('jquery');
 }
 add_action('wp_enqueue_scripts', 'my_theme_enqueue_scripts');
+
+add_post_type_support( 'page', 'excerpt' );
+
+
+// extends number of custom field names in drop down -----
+
+function customfield_limit_increase( $limit ) {
+    $limit = 200;
+    return $limit;
+  }
+  add_filter( 'postmeta_form_limit', 'customfield_limit_increase' );
+
+// ------  end extend

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -306,7 +306,7 @@ function display_shows_by_category_shortcode($atts) {
 
         $output .= '<div class="show-list">';
         $output .= '<div class="flex justify-between items-center">';
-        $output .= '<h2 class="uppercase text-3xl my-4">' . $category . '</h2>';
+        $output .= '<h2 class="uppercase text-2xl my-4">' . $category . '</h2>';
 
         // Only show link if not on a page with "shows" slug
         if (!$hide_view_all_link && !empty($view_all_link)) {

--- a/theme/index.php
+++ b/theme/index.php
@@ -25,7 +25,7 @@ get_header();
 			if ( is_home() && ! is_front_page() ) :
 				?>
             <header class="entry-header">
-                <!-- <h1 class="entry-title"><?php single_post_title(); ?></h1> -->
+                
             </header><!-- .entry-header -->
             <?php
 			endif;

--- a/theme/template-parts/content/content-page.php
+++ b/theme/template-parts/content/content-page.php
@@ -12,13 +12,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 	<header class="entry-header">
-		<?php
-		if ( ! is_front_page() ) {
-			// the_title( '<h1 class="entry-title">', '</h1>' );
-		} else {
-			the_title( '<h2 class="entry-title">', '</h2>' );
-		}
-		?>
+	
 	</header><!-- .entry-header -->
 
 	<?php cablecast_post_thumbnail(); ?>


### PR DESCRIPTION
This is all set up as a custom page template, which you can set on the right sidebar. The short blurb at the top comes from the page's excerpt and the image is the feature image. The custom fields all populate in the 'get in touch' section, so a client can set any number of them and they'll wrap nicely in that area, four to a line. Whatever content they put into the actual body of the page will display below that; in my case, I have a google iframe that shows a map.

<img width="685" alt="Screenshot 2024-06-04 at 3 06 05 PM" src="https://github.com/trms/wp-cablecast-theme/assets/61241785/00d2259b-7d26-4c23-9b3d-d0f38ce0a362">
<img width="1812" alt="Screenshot 2024-06-04 at 3 06 23 PM" src="https://github.com/trms/wp-cablecast-theme/assets/61241785/b4947d12-3106-42de-b7da-20c2fe92a767">
