### PR TITLE
Add agenda chapters 7 24

### DIFF
--- a/tailwind/custom/components/components.css
+++ b/tailwind/custom/components/components.css
@@ -17,9 +17,17 @@
  * The supplied styles are meant to match the default `h1` classes from
  * Tailwind Typography.
  */
-.page-title,
 .entry-title {
 	@apply max-w-content mx-auto mb-6 text-3xl font-extrabold text-neutral-900;
+}
+.page-title {
+	@apply max-w-full mx-auto text-4xl font-extrabold text-neutral-900;
+}
+.staff-page-title {
+	@apply max-w-content mx-auto mb-3 mt-10 text-3xl font-extrabold text-neutral-900;
+}
+.watch-title {
+	@apply max-w-full mx-auto py-5 uppercase text-4xl font-extrabold text-neutral-900;
 }
 
 /**
@@ -88,6 +96,7 @@ form#loginform {
 
 .login-container {
 	border-radius: 10px;
+	max-width: 600px;
 }
 
 .login-new-membership-container {
@@ -166,14 +175,66 @@ form#loginform {
 		max-height: 40px;
 	}
 }
+
+/* Custom CSS for the Home Page */
+section {
+	padding: 0 10px;
+}
+.homepage-description {
+	max-width: 600px;
+	margin-left: 100px;
+}
+.homepage-description .page-title {
+	color: #fff;
+	margin-top: 0;
+	background-image: none;
+	padding: 0px 0 10px 0;
+}
+#homepage-header {
+	background-size: cover; /* Ensures the background image covers the element */
+	background-position: center; /* Centers the background image */
+	color: #fff;
+	text-shadow: 1px 1px 2px #000;
+}
+.homepage-info-container, .page-info-container, .watch-page-info-container, .schedule-page-info-container, .news-page-info-container {
+	max-width: 1200px;
+	margin-left: auto;
+	margin-right: auto;
+	padding: 50px 10px;
+  }
+  .single-show-page-container, .watch-page-info-container, .schedule-page-info-container, .news-page-info-container, .show-page-info-container {
+	padding: 10px 10px 50px 10px;
+  }
+.homepage-news-container, .homepage-app-container, .homepage-partners-container {
+	max-width: 1200px;
+	margin-left: auto;
+	margin-right: auto;
+}
+#homepage-news-section, #homepage-partners-section {
+	padding: 10px 0;
+}
+
+@media only screen and (max-width: 768px) {
+	.homepage-description {
+		max-width: 100%;
+		margin-left: 0px;
+		text-align: center;
+	}
+}
   
   /* Custom CSS for the About Page */
-  
+
   .about-info-container {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 50px;
 	align-items: center;
+  }
+  .about-info-section {
+	max-width: 1200px;
+	margin-right: auto;
+	margin-left: auto;
+	padding: 50px 0;
   }
 
   @media only screen and (max-width: 768px) {
@@ -198,20 +259,32 @@ form#loginform {
   .about-page-main-content {
 	margin: 50px 0;
   }
+  .about-social-media-container {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+  }
+  
   #categories {
 	display: flex;
 	flex-direction: column;
-	
+
   }
- /* Custom Css for the About us Page */ 
+
   .app-information {
-	border-top: 1px solid #bbb;
+	padding: 20px 0 50px 0;
   }
   .app-icons-container {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	gap: 30px;
+  }
+  .contact-section-container {
+	max-width: 1200px;
+	margin-right: auto;
+	margin-left: auto;
+	padding: 20px 0;
   }
   .contact-info-container {
     display: grid;
@@ -233,7 +306,7 @@ form#loginform {
 	}
   }
   
-  .contact-info-title, .app-info-title {
+  .contact-info-title, .app-info-title, H3.wp-block-heading {
 	font-size: 1.5rem;
 	font-weight: bold;
 	text-align: center;
@@ -256,46 +329,28 @@ form#loginform {
   }
 
   /* Misc CSS to tweak the whole site */ 
-  
+ 
   #categories .show-list {
 	border-bottom: 1px solid #bbb;
 	padding: 30px 0;
   }
 
   #content {
-	max-width: 1200px !important;
-	padding: 0 10px;
+	max-width: 100% !important;
   }
 
   .footer-copyright {
 	color: #fff;
 	text-align: center;
   }
-
-  .homepage-info-container {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 50px;
-	align-items: center;
-	margin-top: 20px;
-	padding-bottom: 40px;
-	border-bottom: 1px solid #bbb;
+  footer {
+	box-shadow: 0px -5px 7px rgba(0, 0, 0, 0.09);
   }
-
-  .homepage-description {
-	flex: 50%;
-  }
-  
-  .homepage-feature-image {
-	flex: 40%;
-  }
-
   hr.homepage-hr {
 	border-color: #bbb;
   }
 
   .menu-header-nav-container #primary-menu {
-	gap: 10px;
 	text-transform: uppercase;
   }
 
@@ -304,7 +359,6 @@ form#loginform {
   }
 
   .page-title {
-	margin-top: 30px;
 	text-transform: uppercase;
   }
 
@@ -313,6 +367,17 @@ form#loginform {
 	background-color: #E5E7EB;
 	margin: 0.15rem;
 	color: inherit;
+  }
+  .show-archive-background {
+	background-color: #fff !important;
+  }
+
+  #show-search {
+	font-size: 1rem;
+	font-weight: normal;
+	line-height: normal;
+	width: 100%;
+	max-width: 900px;
   }
 
 .subscription {
@@ -338,7 +403,9 @@ form#loginform {
   .show-title {
 	white-space: nowrap;
   }
-
+  #show-thumbnails {
+	padding: 0 !important;
+  }
   .show-container {
 	display: block;
 	overflow: hidden;
@@ -346,21 +413,20 @@ form#loginform {
   }
 
 /* Custom CSS for the Channels pages */
-
-.channel-archive-thumbnail {
+.channels-page-info-container {
+	max-width: 900px;
+	margin-right: auto;
+	margin-left: auto;
+	padding: 0 10px;
+}
+.channel-archive-thumbnail img {
 	background-color: #fff;
 	border: 1px solid #bbb;
-	border-radius: 10px;
 	max-width: 300px;
 	overflow: hidden;
   }
 
 .channel-archive-container {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-around;
-	gap: 30px;
-	align-items: center;
 	padding-bottom: 50px;
 	margin-top: 50px;
   }
@@ -374,6 +440,17 @@ form#loginform {
 	margin-top: 10px;
 	text-transform: uppercase;
   }
+  .channel-archive-item {
+	display: flex;
+  }
+  @media screen and (max-width: 800px) {
+    .channel-archive-item {
+		display: block;
+	  }
+	.channel-archive-thumbnail img {
+		margin-bottom: 10px;
+	}
+}
 
   /* Custom CSS for the Watch page */
 
@@ -434,15 +511,49 @@ form#loginform {
   .schedule-page-nagivation, .watch-page-nagivation {
 	display: flex;
 	justify-content: space-between;
+	margin-bottom: 10px;
   }
 
   .schedule-date-navigation {
+	display: grid;
+	grid-template-columns: auto auto auto;
+	gap: 1rem;
+	align-items: center;
+  }
+  .schedule-header-container {
 	display: flex;
 	justify-content: space-between;
-	margin: 3px 0;
+	margin-bottom: 10px;
+  }
+  @media screen and (max-width: 900px) {
+	.schedule-header-container {
+		display: block;
+	}
+	.schedule-date-navigation {
+		margin: 10px 0;
+	}
+	.schedule-next-btn {
+		text-align: right;
+	}
+	.schedule-date-navigation form {
+		display: flex;
+		justify-content: center;
+	}
   }
   .schedule-time {
 	min-width: 100px;
+  }
+  .watch-button {
+	text-shadow: none;
+	text-transform: capitalize;
+	max-width: 150px;
+	margin-left: auto;
+	margin-right: auto;
+	margin-top: 20px;
+	display: block;
+  }
+  .watch-button:hover {
+	text-decoration: none !important;
   }
 
   /* Custom CSS for Edit Profile Page */
@@ -537,3 +648,143 @@ form#loginform {
 .footer-social-media-container img {
 	max-width: 30px ;
 }
+
+/* Custom CSS for staff pages */
+#staff-page-content, #single-staff-page-content {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding-top: 20px;
+}
+#single-staff-page-content {
+	padding-bottom: 30px;
+}
+.clear-float {
+	clear:left;
+}
+
+.staff-item-container {
+	flex: 0 0 20%; /* Each item takes up 20% of the container's width */
+	padding: 0 20px 50px 20px;
+    box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+@media (max-width: 800px) {
+    .staff-item-container {
+      flex: 0 0 25%; /* Adjusting for smaller screens */
+    }
+}
+
+@media (max-width: 600px) {
+    .staff-item-container {
+      flex: 0 0 33.33%; /* Adjusting for even smaller screens */
+    }
+}
+
+@media (max-width: 400px) {
+    .staff-item-container {
+      flex: 0 0 50%; /* Adjusting for the smallest screens */
+    }
+}
+
+.staff-item-title {
+	font-size: 1.25rem;
+	font-weight: bold;
+  }
+.staff-listing-container {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	width: 100%;
+	text-align: center;
+	padding-top: 20px;
+}
+.staff-single-page-content {
+	margin-right: auto;
+	margin-left: auto;
+	max-width: 1200px;
+  }
+.staff-thumbnail-single {
+	max-width: 300px;
+	float: left;
+	margin-right: 20px;
+	margin-bottom: 10px;
+	display: block;
+}
+@media screen and (max-width: 900px) {
+    .staff-thumbnail-single {
+		float: none;
+		margin: 20px auto;
+		display: block;
+	}
+}
+
+/* Custom CSS for the Restricted content message */
+
+.restricted-content-message {
+	width: 100%;
+	border: 1px solid #bbb;
+	padding: 10px;
+	border-radius: 10px;
+	text-align: center;
+	background-color: #f9f9f9;
+  }
+  
+  /* Custom CSS for Footer Social media */
+  
+  .footer-social-media-container img {
+	max-width: 30px ;
+  }
+  
+/* custom css for the single news page */
+.news-single-title {
+	max-width: 1200px;
+	margin-left: auto;
+	margin-right: auto;
+}
+.news-page-info-container {
+	max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 10px;
+}
+
+/* custom css for dropdown menus */
+.menu-header-nav-container li.menu-item-has-children {
+	position: relative;
+  	display: inline-block;
+}
+
+.menu-header-nav-container .sub-menu {
+	display: none;
+	position: absolute;
+	min-width: 200px;
+	width: 100%;
+	overflow: auto;
+	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	z-index: 1;
+	margin-top: 20px;
+  }
+
+  .menu-header-nav-container .sub-menu li a {
+	float: none;
+	padding: 12px 16px;
+	text-decoration: none;
+	display: block;
+	text-align: left;
+  }
+
+  li.menu-item-has-children:hover .sub-menu {
+	display: block;
+  }
+
+  .menu-header-nav-container .menu-item {
+	padding: 25px 16px;
+  }
+  .menu-header-nav-container .menu-item .sub-menu li {
+	padding: 0;
+  }
+  .menu-header-nav-container .menu-item.btn {
+	padding: .5rem 1rem;
+  }

--- a/tailwind/custom/components/components.css
+++ b/tailwind/custom/components/components.css
@@ -788,3 +788,34 @@ section {
   .menu-header-nav-container .menu-item.btn {
 	padding: .5rem 1rem;
   }
+
+  /* Custom CSS for the Agenda PDF embed */
+  .pdf-embed {
+	height: 100vh; /* Full viewport height */
+    min-height: 550px; /* Minimum height */
+	width: 100%;
+  }
+
+  #pdf-canvas {
+	width: 100%;
+	height: 100%;
+	min-height: 550px;
+}
+
+/* custom css for the show page */
+.show-chapters-container, .show-agenda-container {
+	max-width: 1200px;
+	margin-right: auto;
+	margin-left: auto;
+	padding-bottom: 30px;
+}
+.show-chapters-container li:nth-child(4n), .show-chapters-container li:nth-child(4n-1) {
+	background-color: #f9f9f9;
+}
+.show-chapters-container li {
+	padding: 10px 10px;
+	border-bottom: 1px solid #bbb;
+}
+.show-chapters-container {
+	grid-template-columns: auto 75%;
+}

--- a/tailwind/custom/components/components.css
+++ b/tailwind/custom/components/components.css
@@ -819,3 +819,15 @@ section {
 .show-chapters-container {
 	grid-template-columns: auto 75%;
 }
+
+/* Custom CSS for the show table view page */
+.show-table-container tr:nth-child(even) {
+	background-color: #f9f9f9;
+}
+.show-table-container td, .show-table-container th {
+	vertical-align: middle;
+}
+.show-table-list {
+	border-bottom: 1px solid #bbb;
+	padding: 30px 0;
+}

--- a/tailwind/tailwind.config.js
+++ b/tailwind/tailwind.config.js
@@ -31,6 +31,9 @@ module.exports = {
 		// Add Tailwind Typography (via _tw fork).
 		require('@_tw/typography'),
 
+		// Add Tailwind Forms
+		require('@tailwindcss/forms'),
+
 		// Extract colors and widths from `theme.json`.
 		require('@_tw/themejson'),
 

--- a/theme/about-template.php
+++ b/theme/about-template.php
@@ -7,24 +7,29 @@ Template Name: Cablecast About Page
 get_header();
 ?>
 
-<section id="primary">
-        <main id="main">
-		
-        <h2 class="page-title text-center"><?php single_post_title(); ?></h2>
+<main id="main" class="about-page-main">
+    <h2 class="page-title text-center accent-color title-text-color"><?php single_post_title(); ?></h2>
 
-        <div class="about-info-container">
-            <div class="about-feature-image"><?php echo the_post_thumbnail(); ?></div>
-            <div class="about-description"><?php the_excerpt(); ?></div>
+  <section>
+		<div class="about-info-section">
+            
+
+            <div class="about-info-container">
+                <div class="about-feature-image"><?php echo the_post_thumbnail(); ?></div>
+                <div class="about-description">
+                    <?php the_excerpt(); ?>
+                    <a href="/staff" class="!text-brand-accent hover:underline">Meet our staff »</a>
+                </div>
+            </div>
         </div>
-
-        <!-- put featured custom collection here? -->
-
+</section>
             <?php
-            // Retrieve the settings
+            // Retrieve the Contact info settings
             $contact_info = get_option('contact_info_settings');
             ?>
-
-        <h3 class="contact-info-title">GET IN TOUCH</h3>
+    <section class="section-1-background">
+        <div class="contact-section-container">
+        <h3 class="contact-info-title heading-text-color">GET IN TOUCH</h3>
         <div class="contact-info-container">
             <?php
             $columns = [];
@@ -41,6 +46,10 @@ get_header();
             if ($contact_info['fax']) {
                 $columns[] = '<div class="contact-info-column"><span class="meta-title">Fax:</span> <a href="tel:' . esc_html($contact_info['fax']) . '" class="!text-brand-accent hover:underline" target="_blank">' . esc_html($contact_info['fax']) . '</a></div>';
             }
+            if ($contact_info['hours']) {
+                $hours_with_line_breaks = nl2br(esc_html($contact_info['hours']));
+                $columns[] = '<div class="contact-info-column"><span class="meta-title">Hours:</span> ' . $hours_with_line_breaks . '</div>';
+            }
 
             // Output the columns
             foreach ($columns as $column) {
@@ -48,15 +57,17 @@ get_header();
             }
             ?>
         </div>
-
+    
         <div class="about-page-main-content"><?php the_content(); ?></div>
+        </div>
+    </section>
 
         <?php
         if ($contact_info) { ?>
 
-            <div class="app-information mb-10">
+            <section class="app-information">
 
-                <h3 class="app-info-title">Find us on your favorite app</h3>
+                <h3 class="app-info-title heading-text-color">Find us on your favorite app</h3>
 
                 <div class="app-icons-container">
                     <?php // Display each app link and image
@@ -70,11 +81,11 @@ get_header();
                         }
                     } ?>
                 </div>
-            </div>
+                </section>
 
         <?php } ?>
 
-        </main><!-- #main -->
-    </section><!-- #primary -->
+
+</main>
 
 <?php get_footer(); ?>

--- a/theme/about-template.php
+++ b/theme/about-template.php
@@ -18,7 +18,7 @@ get_header();
                 <div class="about-feature-image"><?php echo the_post_thumbnail(); ?></div>
                 <div class="about-description">
                     <?php the_excerpt(); ?>
-                    <a href="/staff" class="!text-brand-accent hover:underline">Meet our staff »</a>
+                    <a href="/staff" class="link-color hover:underline">Meet our staff »</a>
                 </div>
             </div>
         </div>
@@ -35,16 +35,16 @@ get_header();
             $columns = [];
 
             if ($contact_info['email']) {
-                $columns[] = '<div class="contact-info-column"><span class="meta-title">Email:</span> <a href="mailto:' . esc_html($contact_info['email']) . '" class="!text-brand-accent hover:underline" target="_blank">' . esc_html($contact_info['email']) . '</a></div>';
+                $columns[] = '<div class="contact-info-column"><span class="meta-title">Email:</span> <a href="mailto:' . esc_html($contact_info['email']) . '" class="link-color hover:underline" target="_blank">' . esc_html($contact_info['email']) . '</a></div>';
             }
             if ($contact_info['address']) {
-                $columns[] = '<div class="contact-info-column"><span class="meta-title">Address:</span> <a href="https://www.google.com/maps/search/?api=1&query=' . urlencode($contact_info['address']) . '" class="!text-brand-accent hover:underline" target="_blank">' . esc_html($contact_info['address']) . '</a></div>';
+                $columns[] = '<div class="contact-info-column"><span class="meta-title">Address:</span> <a href="https://www.google.com/maps/search/?api=1&query=' . urlencode($contact_info['address']) . '" class="link-color hover:underline" target="_blank">' . esc_html($contact_info['address']) . '</a></div>';
             }
             if ($contact_info['phonenumber']) {
-                $columns[] = '<div class="contact-info-column"><span class="meta-title">Phone Number:</span> <a href="tel:' . esc_html($contact_info['phonenumber']) . '" class="!text-brand-accent hover:underline" target="_blank">' . esc_html($contact_info['phonenumber']) . '</a></div>';
+                $columns[] = '<div class="contact-info-column"><span class="meta-title">Phone Number:</span> <a href="tel:' . esc_html($contact_info['phonenumber']) . '" class="link-color hover:underline" target="_blank">' . esc_html($contact_info['phonenumber']) . '</a></div>';
             }
             if ($contact_info['fax']) {
-                $columns[] = '<div class="contact-info-column"><span class="meta-title">Fax:</span> <a href="tel:' . esc_html($contact_info['fax']) . '" class="!text-brand-accent hover:underline" target="_blank">' . esc_html($contact_info['fax']) . '</a></div>';
+                $columns[] = '<div class="contact-info-column"><span class="meta-title">Fax:</span> <a href="tel:' . esc_html($contact_info['fax']) . '" class="link-color hover:underline" target="_blank">' . esc_html($contact_info['fax']) . '</a></div>';
             }
             if ($contact_info['hours']) {
                 $hours_with_line_breaks = nl2br(esc_html($contact_info['hours']));

--- a/theme/archive-cablecast_channel.php
+++ b/theme/archive-cablecast_channel.php
@@ -1,22 +1,27 @@
 <?php get_header(); ?>
+<main id="main">
+  <article>
+  <h2 class="page-title text-center accent-color title-text-color">CHANNELS</h2>  
+  <div class="channels-page-info-container">
 
-<h2 class="page-title text-center">CHANNELS</h2>
+    <div class="channel-archive-container">
+      <?php
+        while (have_posts()) {
+          the_post(); 
+          $permalink = get_permalink(); // Retrieve post permalink ?>
+            <div class="channel-archive-item gap-10 pb-10">
+              <div class="channel-archive-thumbnail mt-2"><?php echo the_post_thumbnail(); ?></div>
+              <div>
+                <h3 class="channel-archive-titles pb-2 heading-text-color"><?php the_title(); ?></h3>
+                <?php the_content(); ?>
+                <div class="py-5">
+                  <a href="<?php echo $permalink; ?>watch" class="text-center grow rounded secondary-button px-4 py-2 mr-3 text-xs font-semibold text-white shadow-sm">Watch Channel</a>  <a href="<?php echo $permalink; ?>schedule" class="text-center grow rounded secondary-button px-4 py-2 text-xs font-semibold text-white shadow-sm">View Schedule</a>
+                </div>
+              </div>
+            </div>
+      <?php } ?>
 
-<div class="channel-archive-container">
-  <?php
-    while (have_posts()) {
-      the_post(); 
-      $permalink = get_permalink(); // Retrieve post permalink ?>
-        <div class="channel-archive-item">
-            <h3 class="channel-archive-titles"><?php the_title(); ?></h3>
-          <div class="channel-archive-thumbnail"><?php echo the_post_thumbnail(); ?></div>
-          <div class="pt-3 pb-3 flex flex-row gap-4 justify-center"><a href="<?php echo $permalink; ?>watch" class="text-center grow rounded secondary-button px-2 py-2 text-xs font-semibold text-white shadow-sm">Watch Channel</a>  <a href="<?php echo $permalink; ?>schedule" class="text-center grow rounded secondary-button px-2 py-2 text-xs font-semibold text-white shadow-sm">View Schedule</a></div>
-          <div><?php the_content(); ?></div>
-        </div>
-        
-      
-  <?php } ?>
-
-</div>
-
+    </div>
+  </div><article>
+</main>
 <?php get_footer(); ?>

--- a/theme/archive-cablecast_channel.php
+++ b/theme/archive-cablecast_channel.php
@@ -15,7 +15,7 @@
                 <h3 class="channel-archive-titles pb-2 heading-text-color"><?php the_title(); ?></h3>
                 <?php the_content(); ?>
                 <div class="py-5">
-                  <a href="<?php echo $permalink; ?>watch" class="text-center grow rounded secondary-button px-4 py-2 mr-3 text-xs font-semibold text-white shadow-sm">Watch Channel</a>  <a href="<?php echo $permalink; ?>schedule" class="text-center grow rounded secondary-button px-4 py-2 text-xs font-semibold text-white shadow-sm">View Schedule</a>
+                  <a href="<?php echo $permalink; ?>watch" class="text-center rounded secondary-button px-4 py-2 mr-3 text-xs font-semibold text-white shadow-sm">Watch Channel</a>  <a href="<?php echo $permalink; ?>schedule" class="text-center rounded secondary-button px-4 py-2 text-xs font-semibold text-white shadow-sm">View Schedule</a>
                 </div>
               </div>
             </div>

--- a/theme/archive-news.php
+++ b/theme/archive-news.php
@@ -1,37 +1,40 @@
 <?php get_header(); ?>
+<main id="main">
+  <article>
+    <h2 class="page-title text-center accent-color title-text-color">NEWS</h2>
+  <div class="news-page-info-container">
+    
+    <div class="news-container">
+      <?php 
+        while (have_posts()) {
+          the_post(); ?>
 
-<h2 class="page-title text-center">NEWS</h2>
+            <div class="news-item">
+              <div class="news-thumbnail-archive"><?php echo the_post_thumbnail('newsHomepage'); ?></div>
 
-<div class="container">
-  <?php 
-    while (have_posts()) {
-      the_post(); ?>
+              <div class="news-item-text">
+                <div class="news-date">
+                  <?php the_time('n.j.y'); ?>
+                </div>
+                
+                <h3 class="news-item-title heading-text-color"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
 
-        <div class="news-item">
-          <div class="news-thumbnail-archive"><?php echo the_post_thumbnail(); ?></div>
+                <div class="news-content">
+                  <?php if (has_excerpt()) {
+                          echo get_the_excerpt();
+                        } else {
+                          echo wp_trim_words(get_the_content(), 18);
+                        }  ?>
+                  <p><a class="news-readmore-btn !text-brand-accent hover:underline pt-3 block" href="<?php the_permalink(); ?>">Continue reading &raquo;</a></p>
+                </div>
+              </div>
 
-          <div class="news-item-text">
-            <div class="news-date">
-              <?php the_time('n.j.y'); ?>
             </div>
-            
-            <h3 class="news-item-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-
-            <div class="news-content">
-              <?php if (has_excerpt()) {
-                      echo get_the_excerpt();
-                    } else {
-                      echo wp_trim_words(get_the_content(), 18);
-                    }  ?>
-              <p><a class="news-readmore-btn !text-brand-accent hover:underline pt-3 block" href="<?php the_permalink(); ?>">Continue reading &raquo;</a></p>
-            </div>
-          </div>
-
+      <?php } ?>
+        <div class="news-pagination-container">
+        <?php echo paginate_links();?>
         </div>
-  <?php } ?>
-    <div class="news-pagination-container">
-    <?php echo paginate_links();?>
     </div>
-</div>
-
+  </section>
+</main>
 <?php get_footer(); ?>

--- a/theme/archive-news.php
+++ b/theme/archive-news.php
@@ -25,7 +25,7 @@
                         } else {
                           echo wp_trim_words(get_the_content(), 18);
                         }  ?>
-                  <p><a class="news-readmore-btn !text-brand-accent hover:underline pt-3 block" href="<?php the_permalink(); ?>">Continue reading &raquo;</a></p>
+                  <p><a class="news-readmore-btn link-color hover:underline pt-3 block" href="<?php the_permalink(); ?>">Continue reading &raquo;</a></p>
                 </div>
               </div>
 

--- a/theme/archive-old.php
+++ b/theme/archive-old.php
@@ -10,8 +10,8 @@
 get_header();
 ?>
 
-	<section id="primary">
-		<main id="main">
+<main id="main">
+<article><div class="page-info-container">
 
 		<?php if ( have_posts() ) : ?>
 
@@ -38,8 +38,8 @@ get_header();
 
 		endif;
 		?>
-		</main><!-- #main -->
-	</section><!-- #primary -->
+		</div><article>
+	</main>
 
 <?php
 get_footer();

--- a/theme/archive-show.php
+++ b/theme/archive-show.php
@@ -1,16 +1,23 @@
 <?php
 get_header();
 ?>
+<main id="main">
+<article>
+    <div class="accent-color page-title">
+        <h2 class="text-center title-text-color mb-5">SHOWS</h2>
+        <!-- Always display the search header and input -->
+        <div class="search-container w-full text-center pb-5">
+            
+            <input type="text" id="show-search" class="border border-gray-400 my-0 mx-auto p-2"
+                placeholder="Search shows">
+        </div>
+    </div>
+    
+    <div class="show-page-info-container">
 
-<div class="entry-content h-full min-h-screen" id="primary">
+<div class="entry-content h-full show-archive-background" id="primary">
     <div id="spinner" class="spinner" style="display: none;"></div>
 
-    <!-- Always display the search header and input -->
-    <div class="search-container w-full text-center">
-        <h2 class="page-title text-center">SHOWS</h2>
-        <input type="text" id="show-search" class="w-3/4 border border-gray-400 my-0 mx-auto p-2"
-            placeholder="Search shows">
-    </div>
 
     <?php
     // Check if the category parameter is set in the URL
@@ -72,7 +79,8 @@ get_header();
         ?>
     </div>
 </div>
-
+    </div><article>
+</main>
 <?php
 get_footer();
 ?>

--- a/theme/archive-staff.php
+++ b/theme/archive-staff.php
@@ -1,0 +1,57 @@
+<?php get_header(); ?>
+
+<main>
+  <article>
+  <h2 class="page-title accent-color title-text-color text-center">MEET OUR STAFF</h2>
+	
+	<div class="page-info-container">
+  <div class="staff-listing-container">
+  <?php 
+    // Custom query to order staff alphabetically by title and display all posts
+    $args = array(
+        'post_type' => 'staff', // Replace 'staff' with your actual custom post type name if different
+        'posts_per_page' => -1, // Display all posts
+        'orderby' => 'title', // Order by title
+        'order' => 'ASC' // Ascending order
+    );
+    $staff_query = new WP_Query($args);
+
+    while ($staff_query->have_posts()) {
+      $staff_query->the_post(); ?>
+
+        <?php
+            // Retrieve custom meta data
+            $phone = get_post_meta(get_the_ID(), '_cep_staff_phone', true);
+            $email = get_post_meta(get_the_ID(), '_cep_staff_email', true);
+            $staffTitle = get_post_meta(get_the_ID(), '_cep_staff_title', true);
+        ?>
+
+        <div class="staff-item-container">
+          <div class="staff-thumbnail-archive"><a href="<?php the_permalink(); ?>"><?php echo the_post_thumbnail('staffSquare'); ?></a></div>
+            
+            <h3 class="staff-item-title heading-text-color"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+            <?php if ($staffTitle) : ?>
+                        <h6 class=""><?php echo esc_html($staffTitle); ?></h6>
+            <?php endif; ?>
+            
+              <?php if ($phone) : ?>
+                  <div><a href="tel:<?php echo esc_html($phone); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($phone); ?></a></div>
+              <?php endif; ?>
+
+              <?php if ($email) : ?>
+                  <div><a href="mailto:<?php echo esc_attr($email); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($email); ?></a></div>
+              <?php endif; ?>
+
+        </div>
+  <?php } 
+    // Reset post data to ensure the main query is not affected
+    wp_reset_postdata();
+  ?>
+    <!-- Add this back in if client wants pagination
+    <div class="news-pagination-container">
+    <?php //echo paginate_links();?>
+    </div> -->
+  </div>
+  </div><article>
+</main>
+<?php get_footer(); ?>

--- a/theme/archive-staff.php
+++ b/theme/archive-staff.php
@@ -35,11 +35,11 @@
             <?php endif; ?>
             
               <?php if ($phone) : ?>
-                  <div><a href="tel:<?php echo esc_html($phone); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($phone); ?></a></div>
+                  <div><a href="tel:<?php echo esc_html($phone); ?>" class="link-color hover:underline"><?php echo esc_html($phone); ?></a></div>
               <?php endif; ?>
 
               <?php if ($email) : ?>
-                  <div><a href="mailto:<?php echo esc_attr($email); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($email); ?></a></div>
+                  <div><a href="mailto:<?php echo esc_attr($email); ?>" class="link-color hover:underline"><?php echo esc_html($email); ?></a></div>
               <?php endif; ?>
 
         </div>

--- a/theme/custom-login-template.php
+++ b/theme/custom-login-template.php
@@ -35,7 +35,7 @@ get_header();
         <main id="main" class="site-main">
             <div>
                 <div>
-                    <div class="login-container w-full sm:w-1/2 mx-auto my-8 p-8 border border-gray-400 primary">
+                    <div class="login-container mx-auto my-8 p-8 border border-gray-400">
                         <h2 class="text-center mb-4 text-2xl font-bold">LOGIN</h2>
                         <form name="loginform" id="loginform" action="" method="post">
                             <p class="login-username flex flex-col gap-y-2">

--- a/theme/custom-login-template.php
+++ b/theme/custom-login-template.php
@@ -65,7 +65,7 @@ get_header();
                             </p>
                             <div class="login-new-membership-container">
                                 <p class="pt-3">Not a member yet?</p>
-                                <a href="/register" class="!text-brand-accent hover:underline">Register your new membership</a>
+                                <a href="/register" class="link-color hover:underline">Register your new membership</a>
                             </div>
                         </form>
 

--- a/theme/front-page.php
+++ b/theme/front-page.php
@@ -8,56 +8,85 @@
  * @package cablecast
  */
 ?>
-<div>
+
     <?php
 get_header();
 ?>
 
-    <section id="primary" class="p-2">
-        <main id="main">
+<main id="main" class="homepage-section-color">
 
-		<?php if (has_excerpt() && has_post_thumbnail()) { ?>
-
+	<?php if (has_excerpt() && has_post_thumbnail()) { ?>
+		<section id="homepage-header" style="background-image: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.75)), url(<?php echo the_post_thumbnail_url(); ?>);">
 			<div class="homepage-info-container">
-				<div class="homepage-feature-image"><?php echo the_post_thumbnail(); ?></div>
 				<div class="homepage-description">
-					<h2 class="page-title">Welcome to <?php echo get_bloginfo( 'name' ); ?></h2>
+					<h2 class="page-title">Welcome to <br><?php echo get_bloginfo( 'name' ); ?></h2>
 					<div><?php the_excerpt(); ?></div>
 				</div>
 			</div>
+		</section>
+	<?php } ?>
 
-		<?php } 
-
-			/* Start the Loop */
+	<section id="homepage-main-content">
+			<?php /* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
 
 				get_template_part( 'template-parts/content/content', 'page' );
 
-			endwhile; // End of the loop.
-			
-			$news_shortcode_output = do_shortcode('[cablecastnews]');
+			endwhile; // End of the loop. ?>
+	</section>		
 
+			<?php // Retrieve the shortcode settings
+			$news_shortcode_output = do_shortcode('[cablecastnews]');
 			$partners_shortcode_output = do_shortcode('[cablecastpartners]');
 
-			if ($news_shortcode_output !== '' or $partners_shortcode_output !== ''){ ?>
-				<hr class="homepage-hr">
+			if ($news_shortcode_output !== '') { ?>
+				<section id="homepage-news-section" class="section-1-background">
+					<div class="homepage-news-container">
+						<h2 class="homepage-news-title text-3xl font-bold text-center heading-text-color">NEWS</h2>
+						<?php echo $news_shortcode_output; ?>
+					</div>
+				</section>
 			<?php }
 
-			if ($news_shortcode_output !== '') { ?>
-				<h2 class="homepage-news-title text-3xl font-bold text-center">NEWS</h2>
-				<?php echo $news_shortcode_output;
-			}
+			// Retrieve the settings
+            $contact_info = get_option('contact_info_settings');
+
+			if ($contact_info) { ?>
+				<section id="homepage-app-info-section">
+					<div class="homepage-app-container mb-20">
+
+						<h3 class="app-info-title text-3xl heading-text-color">Find us on your favorite app</h3>
+
+						<div class="app-icons-container">
+							<?php // Display each app link and image
+							$apps = ['apple', 'roku', 'firetv', 'androidmobile'];
+							foreach ($apps as $app) {
+
+								if (!empty($contact_info[$app . '_image'])) {
+									echo '<a href="' . esc_url($contact_info[$app]) . '" target="_blank">';
+									echo '<img src="' . esc_url($contact_info[$app . '_image']) . '" alt="' . ucfirst($app) . ' Download Image" style="max-width:200px;">';
+									echo '</a>';
+								}
+							} ?>
+						</div>
+					</div>
+				</section>
+
+			<?php }
+
 			if ($partners_shortcode_output !== '') { ?>
-				<h2 class="homepage-partners-title text-3xl font-bold text-center">PARTNERS</h2>
-				<?php echo $partners_shortcode_output;
-			}
+				<section id="homepage-partners-section">
+					<div class="homepage-partners-container">
+						<h2 class="homepage-partners-title text-3xl font-bold text-center heading-text-color">OUR PARTNERS</h2>
+						<?php echo $partners_shortcode_output; ?>
+					</div>
+				</section>
+			<?php } ?>
 
-			?>
+        </main>
 
-        </main><!-- #main -->
-    </section><!-- #primary -->
-</div>
+
 <?php
 get_footer();
 

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -318,7 +318,7 @@ function display_shows_by_category_shortcode($atts) {
 
         // Only show link if not on a page with "shows" slug
         if (!$hide_view_all_link && !empty($view_all_link)) {
-            $output .= '<a class="!text-brand-accent no-underline hover:underline mt-5" href="' . $view_all_link . '">View All</a>';
+            $output .= '<a class="link-color no-underline hover:underline mt-5" href="' . $view_all_link . '">View All</a>';
         }
         
         $output .= '</div>';
@@ -513,6 +513,7 @@ function custom_theme_colors( $wp_customize ) {
         'submenu_text_color'         => array(__('Sub Menu Text Color', 'cablecast'), '#FFFFFF'),
         'title_text_color'         => array(__('Page Title Text Color', 'cablecast'), '#FFFFFF'),
         'heading_text_color'         => array(__('Section Heading Text Color', 'cablecast'), '#2DB566'),
+        'link_color'         => array(__('Link Color', 'cablecast'), '#3192C8'),
         'primary_button_color'   => array(__('Primary Button Color', 'cablecast'), '#2DB566'),
         'primary_button_color_hover'   => array(__('Primary Button Hover Color', 'cablecast'), '#199B4D'),
         'secondary_button_color' => array(__('Secondary Button Color', 'cablecast'), '#3192C8'),
@@ -618,6 +619,14 @@ section:nth-child(odd) {
 
 .title-text-color {
     color: <?php echo get_theme_mod('title_text_color', '#FFFFFF'); ?>;
+}
+
+.link-color {
+    color: <?php echo get_theme_mod('link_color', '#3192c8'); ?>;
+}
+
+.tab-border-color {
+    border-color: <?php echo get_theme_mod('link_color', '#3192c8'); ?>;
 }
 
 .heading-text-color, .rcp-table-wrapper h3, .rcp_form legend, .wp-block-heading {

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -77,6 +77,11 @@ if ( ! function_exists( 'cablecast_setup' ) ) :
 		 */
 		add_theme_support( 'post-thumbnails' );
 
+        // add a custom image size. Name, width, height, crop the image (true/false)
+        add_image_size('staffPortrait', 700, 800, true);
+        add_image_size('staffSquare', 700, 700, true);
+        add_image_size('newsHomepage', 338, 190, true);
+
 		register_nav_menus(
 			array(
 				'menu-1' => __( 'Primary', 'cablecast' ),
@@ -85,6 +90,8 @@ if ( ! function_exists( 'cablecast_setup' ) ) :
 				'menu-4' => __( 'Footer Menu Col-3', 'cablecast' ),
 				'menu-5' => __( 'Footer Menu Col-4', 'cablecast' ),
 			)
+        
+
 		);
 
 		/*
@@ -211,7 +218,7 @@ function search_shows_callback() {
     // Render thumbnails of matching shows
     if ($query->have_posts()) {
         $output .= '<div class="show-list mt-8">';
-        $output .= '<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">'; 
+        $output .= '<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-10">'; 
 
         while ($query->have_posts()) {
             $query->the_post();
@@ -307,7 +314,7 @@ function display_shows_by_category_shortcode($atts) {
 
         $output .= '<div class="show-list">';
         $output .= '<div class="flex justify-between items-center">';
-        $output .= '<h3 class="uppercase text-2xl font-bold mb-4">' . $category . '</h3>';
+        $output .= '<h3 class="uppercase text-2xl font-bold mb-4 heading-text-color">' . $category . '</h3>';
 
         // Only show link if not on a page with "shows" slug
         if (!$hide_view_all_link && !empty($view_all_link)) {
@@ -471,11 +478,41 @@ function custom_theme_colors( $wp_customize ) {
         'priority' => 30,
     ));
 
+    // Add setting for page title background image
+    $wp_customize->add_setting('page_title_background_image', array(
+        'default' => '',
+        'transport' => 'refresh',
+    ));
+
+    // Add control for page title background image
+    $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'page_title_background_image_control', array(
+        'label' => __('Page Title Background Image', 'mytheme'),
+        'section' => 'title_tagline',
+        'settings' => 'page_title_background_image',
+    )));
+
+    // Add setting for section background image
+    $wp_customize->add_setting('section_1_background_image', array(
+        'default' => '',
+        'transport' => 'refresh',
+    ));
+
+    // Add control for section background image
+    $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'section_1_background_image_control', array(
+        'label' => __('Background Image 1', 'mytheme'),
+        'section' => 'title_tagline',
+        'settings' => 'section_1_background_image',
+    )));
+
     // Settings and Controls for Color Options with Defaults
     $colors = array(
-        'banner_color'           => array(__('Banner Color', 'cablecast'), '#545C6E'),
+        'banner_color'           => array(__('Header/Footer Color', 'cablecast'), '#545C6E'),
         'main_background_color'       => array(__('Background Color', 'cablecast'), '#E8E8F0'),
-        'gradient_color'         => array(__('Gradient Color', 'cablecast'), '#576b80'),
+        'accent_color'         => array(__('Accent Color', 'cablecast'), '#3192C8'),
+        'submenu_color'         => array(__('Sub Menu Color', 'cablecast'), '#3192C8'),
+        'submenu_text_color'         => array(__('Sub Menu Text Color', 'cablecast'), '#FFFFFF'),
+        'title_text_color'         => array(__('Page Title Text Color', 'cablecast'), '#FFFFFF'),
+        'heading_text_color'         => array(__('Section Heading Text Color', 'cablecast'), '#2DB566'),
         'primary_button_color'   => array(__('Primary Button Color', 'cablecast'), '#2DB566'),
         'primary_button_color_hover'   => array(__('Primary Button Hover Color', 'cablecast'), '#199B4D'),
         'secondary_button_color' => array(__('Secondary Button Color', 'cablecast'), '#3192C8'),
@@ -507,23 +544,84 @@ function custom_theme_colors( $wp_customize ) {
 }
 add_action('customize_register', 'custom_theme_colors');
 
+function cablecast_customizer_css() { ?>
 
-function cablecast_customizer_css() {
-    ?>
 <style type="text/css">
+    <?php // Set the chosen background image as background for page titles
+$background_image = get_theme_mod('page_title_background_image');
+$background_image_section = get_theme_mod('section_1_background_image');
+    // create css class with background image and some padding/text treatment
+    if ($background_image) {
+        echo '.page-title {
+                background-image: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.75)), url("' . esc_url($background_image) . '");
+                background-size: cover;
+                background-position: center;
+                padding: 50px 0;
+                text-shadow: 2px 2px 2px #000000;
+            }';
+    }
+    else {
+        echo '.page-title {
+                padding: 15px;
+            }';
+    } 
+    // Create CSS class with background image
+    if ($background_image_section) {
+        echo '.section-1-background {
+            background-image: url("' . esc_url($background_image_section) . '");
+            background-size: cover;
+            background-position: center;
+        }';
+    }?>
+
+    /* temporary bug fix for links having underlines */
+a {
+    text-decoration: none !important;
+}
+a:hover {
+    text-decoration: underline !important;
+}
+.btn a:hover, .channel-archive-item a:hover {
+    text-decoration: none !important;
+}
+/* end */
+
 .banner {
+    background-color: <?php echo get_theme_mod('banner_color', '#545C6E');
+    ?>;
+}
+body {
     background-color: <?php echo get_theme_mod('banner_color', '#545C6E');
     ?>;
 }
 
 #primary,
 .primary {
-    /* background-color: <?php echo get_theme_mod('main_background_color', '#E8E8F0');
-    ?>; */
+    background-color: <?php echo get_theme_mod('main_background_color', '#E8E8F0');
+    ?>;
 }
 
-.gradient {
-    background-image: linear-gradient(<?php echo get_theme_mod('gradient_color', '#576b80'); ?>, <?php echo get_theme_mod('background_color', '#ffffff'); ?>);
+section:nth-child(odd) {
+    background-color: <?php echo get_theme_mod('main_background_color', '#E8E8F0');
+    ?>;
+}
+
+.accent-color {
+    background-color: <?php echo get_theme_mod('accent_color', '#3192C8'); ?>;
+}
+.menu-header-nav-container .sub-menu {
+    background-color: <?php echo get_theme_mod('submenu_color', '#3192C8'); ?>;
+}
+.menu-header-nav-container .sub-menu a {
+    color: <?php echo get_theme_mod('submenu_text_color', '#FFFFFF'); ?>;
+}
+
+.title-text-color {
+    color: <?php echo get_theme_mod('title_text_color', '#FFFFFF'); ?>;
+}
+
+.heading-text-color, .rcp-table-wrapper h3, .rcp_form legend, .wp-block-heading {
+    color: <?php echo get_theme_mod('heading_text_color', '#2DB566'); ?>;
 }
 
 .primary-button {

--- a/theme/header.php
+++ b/theme/header.php
@@ -25,10 +25,10 @@
 
     <?php wp_body_open(); ?>
 
-    <div id="page" class="flex min-h-screen flex-col justify-between bg-brand-secondary">
+    <div id="page" class="flex flex-col justify-between bg-brand-secondary">
         <a href="#content" class="sr-only"><?php esc_html_e( 'Skip to content', 'cablecast' ); ?></a>
-        <div class="flex min-h-screen flex-col justify-between">
+        <div class="flex flex-col justify-between">
             <div>
                 <?php get_template_part( 'template-parts/layout/header', 'content' ); ?>
-            <div class="bg-white w-full pt-7 pb-7">
+            <div class="bg-white w-full">
                 <div id="content" class="background_color">

--- a/theme/header.php
+++ b/theme/header.php
@@ -18,6 +18,7 @@
     <meta charset="<?php bloginfo( 'charset' ); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="profile" href="https://gmpg.org/xfn/11">
+    <script src="https://mozilla.github.io/pdf.js/build/pdf.js"></script>
     <?php wp_head(); ?>
 </head>
 

--- a/theme/inc/template-functions.php
+++ b/theme/inc/template-functions.php
@@ -201,6 +201,6 @@ function cablecast_html5_comment( $comment, $args, $depth ) {
 				);
 			}
 			?>
-		</article><!-- .comment-body -->
+		</div><article><!-- .comment-body -->
 	<?php
 }

--- a/theme/index.php
+++ b/theme/index.php
@@ -16,8 +16,8 @@
     <?php
 get_header();
 ?>
-    <section id="primary">
-        <main id="main">
+<main id="main">
+<article><div class="page-info-container">
 
             <?php
 		if ( have_posts() ) {
@@ -47,8 +47,8 @@ get_header();
 		}
 		?>
 
-        </main><!-- #main -->
-    </section><!-- #primary -->
+	</div><article>
+	</main>
 </div>
 <?php
 get_footer();

--- a/theme/page.php
+++ b/theme/page.php
@@ -16,9 +16,12 @@
 get_header();
 ?>
 
-    <section id="primary" class="p-2">
-        <main id="main">
-		<h2 class="page-title text-center"><?php single_post_title(); ?></h2>
+<main id="main">
+<article>
+	<h2 class="page-title accent-color title-text-color text-center"><?php single_post_title(); ?></h2>
+	
+	<div class="page-info-container">
+		
             <?php
 
 			/* Start the Loop */
@@ -35,8 +38,8 @@ get_header();
 			endwhile; // End of the loop.
 			?>
 
-        </main><!-- #main -->
-    </section><!-- #primary -->
+		</div><article>
+		</main>
 </div>
 <?php
 get_footer();

--- a/theme/search.php
+++ b/theme/search.php
@@ -10,8 +10,8 @@
 get_header();
 ?>
 
-<section id="primary">
-    <main id="main">
+<main id="main">
+<article><div class="page-info-container">
 
         <?php if ( have_posts() ) : ?>
 
@@ -45,8 +45,8 @@ get_header();
 
 		endif;
 		?>
-    </main><!-- #main -->
-</section><!-- #primary -->
+	</div><article>
+</main>
 
 <?php
 get_footer();

--- a/theme/show-table-template.php
+++ b/theme/show-table-template.php
@@ -1,0 +1,176 @@
+<?php
+/*
+Template Name: Show Table View
+*/
+// Start the WordPress session
+get_header();
+?>
+<main id="main">
+<article>
+    <div class="accent-color page-title">
+        <h2 class="text-center title-text-color mb-5">SHOWS LIST</h2>
+        <!-- Always display the search header and input -->
+        <div class="search-container w-full text-center pb-5">
+            
+            <input type="text" id="show-search" class="border border-gray-400 my-0 mx-auto p-2"
+                placeholder="Search shows">
+        </div>
+    </div>
+    
+    <div class="show-page-info-container">
+
+<div class="entry-content h-full show-archive-background" id="primary">
+    <div id="spinner" class="spinner" style="display: none;"></div>
+
+
+    <?php
+    // Check if the category parameter is set in the URL
+    if (isset($_GET['category'])) {
+        // Get the value of the category parameter from the URL
+        $category = sanitize_text_field($_GET['category']); // Sanitize the input
+        // Construct the shortcode with the category parameter
+        $shortcode = '[list_shows_by_category category="' . esc_attr($category) . '"]';
+        // Output the shortcode
+        echo '<div id="category-content" class="mt-4">' . do_shortcode($shortcode) . '</div>';
+    }
+    ?>
+
+    <div id="show-thumbnails"></div>
+    <div id="categories-container">
+        <?php
+        // Check if neither category nor search term is present
+        if (!isset($_GET['category']) && !isset($_POST['searchTerm'])) {
+            // Get all categories
+            $categories = get_categories(array(
+                'taxonomy'   => 'category',
+                'hide_empty' => true, // Exclude categories with no posts
+            ));
+
+            // Paginate categories
+            $paged = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
+            $posts_per_page = 10;
+            $total_categories = count($categories);
+            $total_pages = ceil($total_categories / $posts_per_page);
+            $offset = ($paged - 1) * $posts_per_page;
+
+            echo '<div id="categories">';
+            // Loop through each category and display shortcode for each
+            for ($i = $offset; $i < min($offset + $posts_per_page, $total_categories); $i++) {
+                // Construct the shortcode with the dynamic category value
+                $shortcode = '[list_shows_by_category category="' . esc_attr($categories[$i]->name) . '"]';
+                // Output the shortcode
+                echo do_shortcode($shortcode);
+            }
+            echo '</div>';
+
+            // Output pagination buttons
+            if ($total_pages > 1) {
+                echo '<div class="pagination flex justify-center py-5">';
+                if ($paged > 1) {
+                    echo '<a href="#" data-page="' . ($paged - 1) . '" class="button prev px-2 py-1 mx-1 bg-gray-200 hover:bg-gray-300">« Previous</a>';
+                }
+                // Display all page links
+                for ($i = 1; $i <= $total_pages; $i++) {
+                    $current_page_class = ($paged == $i) ? 'bg-white text-black border border-gray-300' : 'bg-gray-200 hover:bg-gray-300';
+                    echo '<a href="#" data-page="' . $i . '" class="button ' . $current_page_class . ' px-2 py-1 mx-1">' . $i . '</a>';
+                }
+                if ($paged < $total_pages) {
+                    echo '<a href="#" data-page="' . ($paged + 1) . '" class="button next px-2 py-1 mx-1 bg-gray-200 hover:bg-gray-300">Next »</a>';
+                }
+                echo '</div>';
+            }
+        }
+        ?>
+    </div>
+</div>
+    </div><article>
+</main>
+<?php
+get_footer();
+?>
+
+<script>
+jQuery(document).ready(function($) {
+    var xhr; // Variable to hold the AJAX request
+
+    $('#show-search').on('input', function() {
+        var searchTerm = $(this).val();
+
+        // If the search term is empty, reload the page
+        if (searchTerm === '') {
+            location.reload();
+            return;
+        }
+
+        // Cancel the previous AJAX request if it's still running
+        if (xhr && xhr.readyState !== 4) {
+            xhr.abort();
+        }
+
+        // Show the spinner
+        $('#spinner').show();
+
+        // Empty the container where shows are displayed
+        $('#show-thumbnails').empty();
+        $('#categories-container').empty();
+        $('#category-content').empty(); // Remove the category content
+        $('#category-content').hide();
+
+        // Perform AJAX request to retrieve matching shows
+        xhr = $.ajax({
+            url: '<?php echo admin_url('admin-ajax.php'); ?>',
+            type: 'POST',
+            data: {
+                action: 'search_shows',
+                searchTerm: searchTerm
+            },
+            success: function(response) {
+                if (response.trim() === '') {
+                    $('#show-thumbnails').html(
+                        '<p class="no-results-message text-center text-lg font-bold ">No shows found.</p>'
+                    );
+
+                } else {
+                    $('#show-thumbnails').html(response);
+                }
+                $('#spinner')
+                    .hide(); // Hide the spinner once the AJAX request is successful
+            },
+            error: function(xhr, status, error) {
+                console.error(xhr.responseText);
+                $('#spinner').hide(); // Hide the spinner in case of an error
+            }
+        });
+    });
+
+    $(document).on('click', '.pagination a', function(e) {
+        e.preventDefault();
+        var page = $(this).data('page');
+
+        // Show the spinner
+        $('#spinner').show();
+
+        // Perform AJAX request to load categories
+        $.ajax({
+            url: '<?php echo admin_url('admin-ajax.php'); ?>',
+            type: 'POST',
+            data: {
+                action: 'load_categories',
+                page: page
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#categories-container').html(response.data.categories + response.data
+                        .pagination);
+                }
+                $('#spinner')
+                    .hide(); // Hide the spinner once the AJAX request is successful
+            },
+            error: function(xhr, status, error) {
+                console.error(xhr.responseText);
+                $('#spinner').hide(); // Hide the spinner in case of an error
+            }
+        });
+    });
+});
+</script>

--- a/theme/single-cablecast_channel-schedule.php
+++ b/theme/single-cablecast_channel-schedule.php
@@ -18,7 +18,7 @@ $permalink = get_permalink(); // Retrieve post permalink?>
         <div class="schedule-page-info-container">
 
             <?php if ($channel_page == 'schedule') {
-        
+
         echo '<div class="schedule-page-nagivation"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a></div>';
         // Display content added through WordPress editor
         if (have_posts()) {

--- a/theme/single-cablecast_channel-schedule.php
+++ b/theme/single-cablecast_channel-schedule.php
@@ -3,30 +3,39 @@
 get_header();
 global $wp_query;
 $channel_slug = get_query_var('cablecast_channel');
-$channel_page = get_query_var('channel_page');
+$channel_page = get_query_var('channel_page'); 
+$permalink = get_permalink(); // Retrieve post permalink?>
 
-if ($channel_page == 'schedule') {
-    $permalink = get_permalink(); // Retrieve post permalink
-    
-    echo '<div class="schedule-page-nagivation"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a>';
+<main id="main">
+    <article>
+        <div class="page-title accent-color">
+            <h2 class="text-center title-text-color"><?php echo esc_html($channel_slug)?> Schedule</h2>
+            <?php if ($channel_page == 'schedule') {
+                echo '<a href="' . $permalink . 'watch" class="watch-button text-center grow rounded secondary-button px-2 py-2 text-sm font-semibold text-white shadow-sm">Watch ' . $channel_slug . '</a>';
+             } ?>
+        </div>
 
-    echo '<a href="' . $permalink . 'watch" class="!text-brand-accent hover:underline capitalize">Watch ' . $channel_slug . ' »</a></div>';
+        <div class="schedule-page-info-container">
 
-    // Load and display schedule content for this channel
-    echo '<h2 class="page-title text-center">' . esc_html($channel_slug) . ' Schedule</h2>';
+            <?php if ($channel_page == 'schedule') {
+        
+        echo '<div class="schedule-page-nagivation"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a></div>';
+        // Display content added through WordPress editor
+        if (have_posts()) {
+            while (have_posts()) { ?>
 
-    // Display content added through WordPress editor
-    if (have_posts()) {
-        while (have_posts()) { ?>
+            <div class="schedule-content-container">
 
-<div class="schedule-content-container">
+                <?php the_post();
+                the_content(); ?>
+            </div>
+            <?php }
+        }
+    }?>
 
-    <?php the_post();
-            the_content(); ?>
-</div>
-<?php }
-    }
-}
+        </div>
+        <article>
+</main>
 
-get_footer();
+<?php get_footer();
 ?>

--- a/theme/single-cablecast_channel-watch.php
+++ b/theme/single-cablecast_channel-watch.php
@@ -3,31 +3,38 @@
 get_header();
 global $wp_query;
 $channel_slug = get_query_var('cablecast_channel');
-$channel_page = get_query_var('channel_page');
+$channel_page = get_query_var('channel_page'); ?>
 
-// Load and display watch content for this channel
-if ($channel_page == 'watch') {
+<main id="main">
+    <article>
+        <div class="watch-page-info-container">
 
-    $permalink = get_permalink(); // Retrieve post permalink
-    
-    echo '<div class="watch-page-nagivation pb-3"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a>';
+            <?php // Load and display watch content for this channel
+    if ($channel_page == 'watch') {
 
-    echo '<a href="' . $permalink . 'schedule" class="!text-brand-accent hover:underline">View Schedule »</a></div>';
+        $permalink = get_permalink(); // Retrieve post permalink
+        
+        echo '<div class="watch-page-nagivation pb-3"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a>';
 
-     // Display content added through WordPress editor
-     if (have_posts()) {
-        while (have_posts()) { ?>
+        // Display content added through WordPress editor
+        if (have_posts()) {
+            while (have_posts()) { ?>
 
-<div class="watch-content-container">
+            <div class="watch-content-container">
 
-    <?php the_post();
-            the_content(); ?>
-</div>
-<?php }
-    }
+                <?php the_post();
+                the_content(); ?>
+            </div>
+            <?php }
+        }
 
-     echo '<h2 class="page-title">' . esc_html($channel_slug) . '</h2>';
-}
-get_footer();
+        echo '<h2 class="watch-title heading-text-color">' . esc_html($channel_slug) . '</h2>';
+    } ?>
+
+        </div>
+        <article>
+</main>
+
+<?php get_footer();
 
 ?>

--- a/theme/single-cablecast_channel-watch.php
+++ b/theme/single-cablecast_channel-watch.php
@@ -14,8 +14,8 @@ $channel_page = get_query_var('channel_page'); ?>
 
         $permalink = get_permalink(); // Retrieve post permalink
         
-        echo '<div class="watch-page-nagivation pb-3"><a href="/channels" class="!text-brand-accent hover:underline">« Back to Channels</a>';
-
+        echo '<div class="watch-page-nagivation pb-3"><a href="/channels" class="link-color hover:underline">« Back to Channels</a>';
+        echo '<a href="' . $permalink . 'schedule" class="link-color hover:underline">View Schedule »</a></div>';
         // Display content added through WordPress editor
         if (have_posts()) {
             while (have_posts()) { ?>

--- a/theme/single-cablecast_channel.php
+++ b/theme/single-cablecast_channel.php
@@ -1,18 +1,24 @@
-<?php get_header(); 
+<?php get_header(); ?>
 
-    while (have_posts()) {
-        the_post(); ?>
-        <a href="/channels" class="!text-brand-accent hover:underline pl-5">« Back to Channels</a>
-        <div class="channel-single-page-container prose pl-5 pr-5">
-            <h2 class="channel-single-page-title"><?php the_title(); ?></h2>
-            
-            <div class="channel-single-page-content">
-                <div class=""><?php the_content(); ?></div>
+<main id="main">
+    <article><div class="page-info-container">
+
+        <?php while (have_posts()) {
+            the_post(); ?>
+            <a href="/channels" class="!text-brand-accent hover:underline pl-5">« Back to Channels</a>
+            <div class="channel-single-page-container prose pl-5 pr-5">
+                <h2 class="channel-single-page-title"><?php the_title(); ?></h2>
+                
+                <div class="channel-single-page-content">
+                    <div class=""><?php the_content(); ?></div>
+                </div>
+
             </div>
-
-        </div>
+            
+        <?php } ?>
         
-    <?php } 
-    
-    get_footer(); 
+    </div><article>
+</main>
+
+    <?php get_footer(); 
     ?>

--- a/theme/single-cablecast_channel.php
+++ b/theme/single-cablecast_channel.php
@@ -5,7 +5,7 @@
 
         <?php while (have_posts()) {
             the_post(); ?>
-            <a href="/channels" class="!text-brand-accent hover:underline pl-5">« Back to Channels</a>
+            <a href="/channels" class="link-color hover:underline pl-5">« Back to Channels</a>
             <div class="channel-single-page-container prose pl-5 pr-5">
                 <h2 class="channel-single-page-title"><?php the_title(); ?></h2>
                 

--- a/theme/single-news.php
+++ b/theme/single-news.php
@@ -1,25 +1,32 @@
-<?php get_header(); 
+<?php get_header(); ?>
 
-    while (have_posts()) {
+<main id="main">
+    <article>
+        <div class="page-title accent-color">
+            <h2 class="news-single-title text-center title-text-color"><?php the_title(); ?></h2>
+        </div>
+    
+    <div class="news-page-info-container">
+    <div><a href="/news" class="!text-brand-accent hover:underline pl-5">« Back to News</a></div>
+
+    <?php while (have_posts()) {
         the_post(); ?>
-        <a href="/news" class="!text-brand-accent hover:underline pl-5">« Back to News</a>
         <div class="news-single-page-content prose">
-            
-            <h2 class="news-single-title page-title"><?php the_title(); ?></h2>
 
-            <div class="news-date">
-                Posted by <?php the_author(); ?> - <?php the_time('n.j.y'); ?>
-            </div>
+            
             
             <div class="news-thumbnail-single"><?php echo the_post_thumbnail(); ?></div> <!-- remove this line to remove the large thumbnail image -->
 
             <div class="news-full-text">
-                <div class=""><?php the_content(); ?></div>
+                <div><?php the_content(); ?></div>
+                <span class="italic text-gray-400 text-sm">Posted by <?php the_author(); ?> - <?php the_time('n.j.y'); ?></span>
             </div>
-
+            <div class="clear-float"></div>
         </div>
         
-    <?php } 
+    <?php } ?>
     
-    get_footer(); 
+    </div><article>
+</main>
+    <?php get_footer(); 
     ?>

--- a/theme/single-news.php
+++ b/theme/single-news.php
@@ -7,7 +7,7 @@
         </div>
     
     <div class="news-page-info-container">
-    <div><a href="/news" class="!text-brand-accent hover:underline pl-5">« Back to News</a></div>
+    <div><a href="/news" class="link-color hover:underline pl-5">« Back to News</a></div>
 
     <?php while (have_posts()) {
         the_post(); ?>

--- a/theme/single-show.php
+++ b/theme/single-show.php
@@ -4,109 +4,100 @@
  *
  * @package cablecast
  */
-
- ?>
+?>
 <div>
-    <?php
- get_header();
- ?>
-<main id="main">
-    <article class="page-info-container single-show-page-container">
+    <?php get_header(); ?>
+    <main id="main">
+        <article class="page-info-container single-show-page-container">
             <?php while (have_posts()) : the_post(); ?>
-            <a href="/shows" class="!text-brand-accent hover:underline block mb-3">« Back to Shows</a>
-            <article <?php post_class(); ?>>
-                <?php
-                $post_id = get_the_ID();
+            <a href="/shows" class="link-color hover:underline block mb-3">« Back to Shows</a>
+            <div class="flex flex-row gap-4">
 
-                // Check if the rcp_user_can_access function exists and run it if so
-                if (function_exists('rcp_user_can_access')) {
-                    $can_access = rcp_user_can_access(get_current_user_id(), $post_id);
-                } else {
-                    // If the function doesn't exist, default to true (access granted)
-                    $can_access = true;
-                }
+                <div class="agenda-left hidden md:block grow">
+                <?php get_template_part('template-parts/content/show-agenda'); ?>
+                </div>
 
-                if ($can_access) {
-                    $video_iframe = get_post_meta($post_id, 'cablecast_vod_embed', true);
-                    if ($video_iframe) {
-                        echo '<div class="embed-responsive">' . $video_iframe . '</div>';
-                    }
-                } else {
-                    $thumbnail_url = get_the_post_thumbnail_url($post_id, 'full');
-                    if ($thumbnail_url) {
-                        echo '<div class="relative">';
-                        echo '<img src="' . esc_url($thumbnail_url) . '" alt="' . esc_attr(get_the_title()) . '" class="attachment-post-thumbnail size-post-thumbnail wp-post-image">';
-                        // Overlay for restricted content
-                        echo '
-                            <div class="absolute bottom-0 left-0 right-0 bg-black bg-opacity-50 text-white text-center py-10">
-                                <div class="flex justify-center flex-col gap-y-2">
-                                    <span>This Content requires a membership to view.</span>
-                                    <span>Login or register below.</span>
-                                    <div class="mt-4">
-                                        <a href="/login" class="btn secondary-button hover:shadow text-white  py-2 px-4 ">Login</a>
-                                        <a href="/register" class="btn secondary-button hover:shadow text-white  py-2 px-4 ">Register</a>
-                                    </div>
-                                </div>  
-                            </div>';
-                        echo '</div>';
-                    }
-                }
+                <div class="video-right max-w-full md:max-w-lg">
+                    <div <?php post_class(); ?>>
+                        <?php
+                        get_template_part('template-parts/content/show-video');
 
-                the_title('<h2 class="text-3xl font-bold mt-8 mb-4 heading-text-color">', '</h2>');
+                        the_title('<h2 class="text-3xl font-bold mt-8 mb-4 heading-text-color">', '</h2>'); ?>
+                        
+                        <!-- Tabs start -->
+                        <div class="show-tabs">
+                            <!-- Code to turn tabs into a drop down
+                            <div class="sm:hidden">
+                                <label for="tabs" class="sr-only">Select a tab</label>
+                            
+                                <select id="tabs" name="tabs" class="block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" onchange="showTabContent(this.value)">
+                                    <option value="details">Details</option>
+                                    <option value="chapters">Chapters</option>
+                                    <option value="agenda">Agenda</option>
+                                </select>
+                            </div> -->
+                            <div class="block"> <!-- Use if using dropdown tabs for mobile: <div class="hidden sm:block"> -->
+                                <div class="border-b border-gray-200">
+                                    <nav class="-mb-px flex" aria-label="Tabs">
+                                        <!-- Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700" -->
+                                        <a href="javascript:void(0);" id="tab-details" class="grow text-center tab-link whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" onclick="showTabContent('details')">Details</a>
+                                        <a href="javascript:void(0);" id="tab-chapters" class="grow text-center tab-link whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" onclick="showTabContent('chapters')">Chapters</a>
+                                        <a href="javascript:void(0);" id="tab-agenda" class="grow text-center tab-link whitespace-nowrap border-b-2 border-transparent px-1 py-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700 block md:hidden" onclick="showTabContent('agenda')">Agenda</a>
+                                    </nav>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Tab content start -->
+                        <div id="tab-content-details" class="tab-content">
+                            <?php get_template_part('template-parts/content/show-detail'); ?>
+                        </div>
+                        <div id="tab-content-chapters" class="tab-content hidden">
+                            <?php get_template_part('template-parts/content/show-chapters'); ?>
+                        </div>
+                        <div class="block md:hidden">
+                        <div id="tab-content-agenda" class="tab-content hidden">
+                            <?php get_template_part('template-parts/content/show-agenda'); ?>
+                        </div>
+                        </div>
+                        <!-- Tab content end -->
+                    </div>
+                </div>
                 
-                echo '<div class="mb-4">' . get_post_meta($post_id, 'cablecast_show_comments', true) . '</div>';
-
-                // Flex container for custom fields in two columns
-                echo '<div class="sm:flex justify-between">';
-                $fields = [
-                    'cablecast_producer_name' => 'Producer',
-                    'cablecast_category_name' => 'Category',
-                    'cablecast_project_name' => 'Project'
-                ];
-                
-                // Retrieve and format the TRT field
-                $trt = get_post_meta($post_id, 'cablecast_show_trt', true);
-                $trtFormatted = $trt ? gmdate("H:i:s", $trt) : '';
-
-                // If TRT is available, add to fields array at the desired position
-                if ($trtFormatted) {
-                    $fields = ['cablecast_show_trt' => 'Length'] + $fields;
-                }
-
-                $col1 = array_slice($fields, 0, 2, true);  // First half of fields
-                $col2 = array_slice($fields, 2, null, true); // Second half of fields
-
-                // Column 1
-                echo '<div class="flex-1 mr-4">';
-                foreach ($col1 as $key => $label) {
-                    $value = get_post_meta($post_id, $key, true);
-                    if ($key == 'cablecast_show_trt') {
-                        $value = $trtFormatted; // Use formatted time for TRT
-                    }
-                    if ($value) {
-                        echo '<div class="mb-2"><span class="font-bold">' . $label . ': </span>' . $value . '</div>';
-                    }
-                }
-                echo '</div>';
-
-                // Column 2
-                echo '<div class="flex-1">';
-                foreach ($col2 as $key => $label) {
-                    $value = get_post_meta($post_id, $key, true);
-                    if ($value) {
-                        echo '<div class="mb-2"><span class="font-bold">' . $label . ': </span>' . $value . '</div>';
-                    }
-                }
-                echo '</div>';
-                
-                echo '</div>';
-                ?>
-            </div><article>
+            </div>
             <?php endwhile; ?>
-    </div><article>
-</main>
+        </article>
+    </main>
+    <?php get_footer(); ?>
 </div>
-<?php
- get_footer();
- ?>
-</div>
+
+<!-- javascript for the tabs -->
+<script>
+function showTabContent(tab) {
+    // Hide all tab content
+    var tabContents = document.querySelectorAll('.tab-content');
+    tabContents.forEach(function(content) {
+        content.classList.add('hidden');
+    });
+
+    // Remove active class from all tabs
+    var tabLinks = document.querySelectorAll('.tab-link');
+    tabLinks.forEach(function(link) {
+        link.classList.remove('tab-border-color', 'link-color');
+        link.classList.add('text-gray-500', 'hover:border-gray-300', 'hover:text-gray-700');
+    });
+
+    // Show the selected tab content
+    document.getElementById('tab-content-' + tab).classList.remove('hidden');
+
+    // Add active class to the selected tab
+    document.getElementById('tab-' + tab).classList.add('tab-border-color', 'link-color');
+    document.getElementById('tab-' + tab).classList.remove('text-gray-500', 'hover:border-gray-300', 'hover:text-gray-700');
+}
+
+// Initialize the first tab as active
+document.addEventListener('DOMContentLoaded', function() {
+    showTabContent('details');
+});
+</script>
+

--- a/theme/single-show.php
+++ b/theme/single-show.php
@@ -10,8 +10,8 @@
     <?php
  get_header();
  ?>
-    <section id="primary" class="content-area p-2">
-        <main id="main" class="site-main pb-8">
+<main id="main">
+    <article class="page-info-container single-show-page-container">
             <?php while (have_posts()) : the_post(); ?>
             <a href="/shows" class="!text-brand-accent hover:underline block mb-3">« Back to Shows</a>
             <article <?php post_class(); ?>>
@@ -52,7 +52,7 @@
                     }
                 }
 
-                the_title('<h2 class="text-3xl font-bold mt-8 mb-4">', '</h2>');
+                the_title('<h2 class="text-3xl font-bold mt-8 mb-4 heading-text-color">', '</h2>');
                 
                 echo '<div class="mb-4">' . get_post_meta($post_id, 'cablecast_show_comments', true) . '</div>';
 
@@ -101,10 +101,10 @@
                 
                 echo '</div>';
                 ?>
-            </article>
+            </div><article>
             <?php endwhile; ?>
-        </main><!-- #main -->
-    </section><!-- #primary -->
+    </div><article>
+</main>
 </div>
 <?php
  get_footer();

--- a/theme/single-staff.php
+++ b/theme/single-staff.php
@@ -17,7 +17,7 @@
         the_post(); ?>
 
         <div class="staff-single-page-content prose">
-         <a href="/staff" class="!text-brand-accent hover:underline">« Back to Staff</a>   
+         <a href="/staff" class="link-color hover:underline">« Back to Staff</a>   
             <div class="staff-info-container">
                 <div class="staff-thumbnail-single"><?php echo the_post_thumbnail('staffPortrait'); ?></div> 
                 
@@ -25,11 +25,11 @@
                 <div class="clear-float"></div>
                 <div class="staff-contact-info pb-10">
                     <?php if ($phone) : ?>
-                        <div><strong>Phone:</strong> <a href="tel:<?php echo esc_html($phone); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($phone); ?></a></div>
+                        <div><strong>Phone:</strong> <a href="tel:<?php echo esc_html($phone); ?>" class="link-color hover:underline"><?php echo esc_html($phone); ?></a></div>
                     <?php endif; ?>
 
                     <?php if ($email) : ?>
-                        <div><strong>Email:</strong> <a href="mailto:<?php echo esc_attr($email); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($email); ?></a></div>
+                        <div><strong>Email:</strong> <a href="mailto:<?php echo esc_attr($email); ?>" class="link-color hover:underline"><?php echo esc_html($email); ?></a></div>
                     <?php endif; ?>
                 </div>
             </div>

--- a/theme/single-staff.php
+++ b/theme/single-staff.php
@@ -1,0 +1,42 @@
+<?php get_header(); ?>
+<main>
+    <article>
+    <?php
+        // Retrieve custom meta data
+        $phone = get_post_meta(get_the_ID(), '_cep_staff_phone', true);
+        $email = get_post_meta(get_the_ID(), '_cep_staff_email', true);
+        $staffTitle = get_post_meta(get_the_ID(), '_cep_staff_title', true);
+    ?>
+        <div class="page-title accent-color mb-3">
+            <h2 class="text-center title-text-color mb-2"><?php the_title(); ?></h2>
+                <?php if ($staffTitle) : ?>
+                        <h3 class="text-center title-text-color text-lg"><?php echo esc_html($staffTitle); ?></h3>
+                <?php endif; ?>
+        </div>
+    <?php while (have_posts()) {
+        the_post(); ?>
+
+        <div class="staff-single-page-content prose">
+         <a href="/staff" class="!text-brand-accent hover:underline">« Back to Staff</a>   
+            <div class="staff-info-container">
+                <div class="staff-thumbnail-single"><?php echo the_post_thumbnail('staffPortrait'); ?></div> 
+                
+                <div class="staff-full-text"><?php the_content(); ?></div>
+                <div class="clear-float"></div>
+                <div class="staff-contact-info pb-10">
+                    <?php if ($phone) : ?>
+                        <div><strong>Phone:</strong> <a href="tel:<?php echo esc_html($phone); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($phone); ?></a></div>
+                    <?php endif; ?>
+
+                    <?php if ($email) : ?>
+                        <div><strong>Email:</strong> <a href="mailto:<?php echo esc_attr($email); ?>" class="!text-brand-accent hover:underline"><?php echo esc_html($email); ?></a></div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+        </div>
+        
+    <?php } ?>
+    </div><article>
+</main>
+    <?php get_footer(); ?>

--- a/theme/single.php
+++ b/theme/single.php
@@ -12,18 +12,18 @@
     <?php
  get_header();
  ?>
-    <section id="primary">
-        <main id="main" class="pb-8">
+<main id="main">
+    <article><div class="page-info-container">
             <?php
 			// Start the Loop.
 			while (have_posts()) :
 				the_post(); ?>
             <article <?php post_class(); ?>>
                 <?php the_content(); ?>
-            </article>
+            </div><article>
             <?php endwhile; // End of the loop. ?>
-        </main><!-- #primary -->
-    </section><!-- #primary -->
+    </div><article>
+</main>
 </div>
 <?php
  get_footer();

--- a/theme/template-parts/content/content-excerpt.php
+++ b/theme/template-parts/content/content-excerpt.php
@@ -27,4 +27,4 @@
     </div><!-- .entry-content -->
 
 
-</article><!-- #post-${ID} -->
+</div><article><!-- #post-${ID} -->

--- a/theme/template-parts/content/content-page.php
+++ b/theme/template-parts/content/content-page.php
@@ -49,4 +49,4 @@
 		</footer><!-- .entry-footer -->
 	<?php endif; ?>
 
-</article><!-- #post-<?php the_ID(); ?> -->
+</div><article><!-- #post-<?php the_ID(); ?> -->

--- a/theme/template-parts/content/content-single.php
+++ b/theme/template-parts/content/content-single.php
@@ -49,4 +49,4 @@
 		?>
     </div><!-- .entry-content -->
 
-</article><!-- #post-${ID} -->
+</div><article><!-- #post-${ID} -->

--- a/theme/template-parts/content/content.php
+++ b/theme/template-parts/content/content.php
@@ -39,4 +39,4 @@
 		?>
     </div><!-- .entry-content -->
 
-</article><!-- #post-${ID} -->
+</div><article><!-- #post-${ID} -->

--- a/theme/template-parts/content/show-agenda.php
+++ b/theme/template-parts/content/show-agenda.php
@@ -1,0 +1,7 @@
+<div class="show-agenda-container">
+<embed src="https://yourtown.cablecast.tv/assets/351/120219.SC%20agenda.revised%203.112719.pdf#navpanes=0" type="application/pdf" class="pdf-embed">
+</div>
+
+<!-- <div class="show-agenda-container">
+<embed src="https://yourtown.cablecast.tv/assets/351/120219.SC%20agenda.revised%203.112719.pdf#toolbar=0&navpanes=0&scrollbar=0" type="application/pdf" class="pdf-embed">
+</div> -->

--- a/theme/template-parts/content/show-chapters.php
+++ b/theme/template-parts/content/show-chapters.php
@@ -1,0 +1,18 @@
+<ul class="show-chapters-container grid mt-2">
+    <li><b>00:00:00</b></li>
+    <li><a href="#" class="link-color">Call to Order</a></li>
+    <li><b>00:01:00</b></li> 
+    <li><a href="#" class="link-color">Pledge of Allegiance</a></li>
+    <li><b>00:02:00</b></li> 
+    <li><a href="#" class="link-color">Attendance</a></li>
+    <li><b>00:03:00</b></li> 
+    <li><a href="#" class="link-color">Public Input</a></li>
+    <li><b>00:04:00</b></li> 
+    <li><a href="#" class="link-color">Appointments: Zoning Board of Adjustment</a></li>
+    <li><b>00:21:00</b></li> 
+    <li><a href="#" class="link-color">Consent Items</a></li>
+    <li><b>00:21:00</b></li> 
+    <li><a href="#" class="link-color">Raffle Permit - Knights of Columbus Council 5162 Hudson</a></li>
+    <li><b>00:21:00</b></li> 
+    <li><a href="#" class="link-color">Outdoor Gathering Permit - Mill Cities Alliance</a></li>
+</ul>

--- a/theme/template-parts/content/show-detail.php
+++ b/theme/template-parts/content/show-detail.php
@@ -26,48 +26,61 @@ if ($agendaDownload) {
 } else {
     echo '<div class="sm:flex justify-between">';
 }
-    $fields = [
-        'cablecast_producer_name' => 'Producer',
-        'cablecast_category_name' => 'Category',
-        'cablecast_project_name' => 'Project'
-    ];
-    
-    // Retrieve and format the TRT field
-    $trt = get_post_meta($post_id, 'cablecast_show_trt', true);
-    $trtFormatted = $trt ? gmdate("H:i:s", $trt) : '';
+$fields = [
+    'cablecast_producer_name' => 'Producer',
+    'cablecast_category_name' => 'Category',
+    'cablecast_project_name' => 'Project',
+];
 
-    // If TRT is available, add to fields array at the desired position
-    if ($trtFormatted) {
-        $fields = ['cablecast_show_trt' => 'Length'] + $fields;
+// Retrieve and format the TRT field
+$trt = get_post_meta($post_id, 'cablecast_show_trt', true);
+$trtFormatted = $trt ? gmdate("H:i:s", $trt) : '';
+
+// Get the event date from post meta
+$eventDate = get_post_meta($post_id, 'cablecast_show_event_date', true);
+
+// Parse the date string using DateTime class
+$date = new DateTime($eventDate);
+
+// Format the date to your desired format'
+$formattedDate = $date->format('m-d-Y');
+
+
+// If TRT is available, add to fields array at the desired position
+if ($trtFormatted) {
+    $fields = ['cablecast_show_trt' => 'Length'] + $fields;
+}
+
+$col1 = array_slice($fields, 0, 2, true);  // First half of fields
+$col2 = array_slice($fields, 2, null, true); // Second half of fields
+
+// Column 1
+echo '<div class="flex-1 mr-4">';
+foreach ($col1 as $key => $label) {
+    $value = get_post_meta($post_id, $key, true);
+    if ($key == 'cablecast_show_trt') {
+        $value = $trtFormatted; // Use formatted time for TRT
     }
-
-    $col1 = array_slice($fields, 0, 2, true);  // First half of fields
-    $col2 = array_slice($fields, 2, null, true); // Second half of fields
-
-    // Column 1
-    echo '<div class="flex-1 mr-4">';
-    foreach ($col1 as $key => $label) {
-        $value = get_post_meta($post_id, $key, true);
-        if ($key == 'cablecast_show_trt') {
-            $value = $trtFormatted; // Use formatted time for TRT
-        }
-        if ($value) {
-            echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
-        }
+    if ($value) {
+        echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
     }
-    echo '</div>';
+}
+if ($eventDate) {
+    echo '<div class="mb-2"><span class="font-bold pr-2">Event Date: </span>' . $formattedDate . '</div>';
+}
+echo '</div>';
 
-    // Column 2
-    echo '<div class="flex-1">';
-    foreach ($col2 as $key => $label) {
-        $value = get_post_meta($post_id, $key, true);
-        if ($value) {
-            echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
-        }
+// Column 2
+echo '<div class="flex-1">';
+foreach ($col2 as $key => $label) {
+    $value = get_post_meta($post_id, $key, true);
+    if ($value) {
+        echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
     }
-    echo '</div>';
-    
-    echo '</div>';
+}
+echo '</div>';
+
+echo '</div>';
 
 echo '</div>';
 // end flex container

--- a/theme/template-parts/content/show-detail.php
+++ b/theme/template-parts/content/show-detail.php
@@ -1,0 +1,74 @@
+
+<?php 
+$post_id = get_the_ID();
+$description = get_post_meta($post->ID, 'Program Description', true);
+
+echo '<div class="mt-4">' . esc_html($description) . '</div>';
+
+echo '<div>' . get_post_meta($post_id, 'cablecast_show_comments', true) . '</div>';
+
+// Buttons to download the agenda and video
+$agendaDownload = true;
+$videoDownload = true;
+echo '<div class="py-5 flex">';
+if ($agendaDownload) { ?>
+    <a href="#" class="w-full sm:w-auto text-center rounded secondary-button px-4 py-2 mr-3 text-xs font-semibold text-white shadow-sm">Download Agenda</a>
+<?php }
+if ($videoDownload) { ?>
+    <a href="#" class="w-full sm:w-auto text-center rounded secondary-button px-4 py-2 text-xs font-semibold text-white shadow-sm">Download Video</a>
+<?php }
+echo '</div>';
+
+
+// Flex container for custom fields in two columns
+if ($agendaDownload) {
+    echo '<div>';
+} else {
+    echo '<div class="sm:flex justify-between">';
+}
+    $fields = [
+        'cablecast_producer_name' => 'Producer',
+        'cablecast_category_name' => 'Category',
+        'cablecast_project_name' => 'Project'
+    ];
+    
+    // Retrieve and format the TRT field
+    $trt = get_post_meta($post_id, 'cablecast_show_trt', true);
+    $trtFormatted = $trt ? gmdate("H:i:s", $trt) : '';
+
+    // If TRT is available, add to fields array at the desired position
+    if ($trtFormatted) {
+        $fields = ['cablecast_show_trt' => 'Length'] + $fields;
+    }
+
+    $col1 = array_slice($fields, 0, 2, true);  // First half of fields
+    $col2 = array_slice($fields, 2, null, true); // Second half of fields
+
+    // Column 1
+    echo '<div class="flex-1 mr-4">';
+    foreach ($col1 as $key => $label) {
+        $value = get_post_meta($post_id, $key, true);
+        if ($key == 'cablecast_show_trt') {
+            $value = $trtFormatted; // Use formatted time for TRT
+        }
+        if ($value) {
+            echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
+        }
+    }
+    echo '</div>';
+
+    // Column 2
+    echo '<div class="flex-1">';
+    foreach ($col2 as $key => $label) {
+        $value = get_post_meta($post_id, $key, true);
+        if ($value) {
+            echo '<div class="mb-2"><span class="font-bold pr-2">' . $label . ': </span>' . $value . '</div>';
+        }
+    }
+    echo '</div>';
+    
+    echo '</div>';
+
+echo '</div>';
+// end flex container
+?>

--- a/theme/template-parts/content/show-video.php
+++ b/theme/template-parts/content/show-video.php
@@ -1,0 +1,37 @@
+<?php
+                $post_id = get_the_ID();
+
+                // Check if the rcp_user_can_access function exists and run it if so
+                if (function_exists('rcp_user_can_access')) {
+                    $can_access = rcp_user_can_access(get_current_user_id(), $post_id);
+                } else {
+                    // If the function doesn't exist, default to true (access granted)
+                    $can_access = true;
+                }
+
+                if ($can_access) {
+                    $video_iframe = get_post_meta($post_id, 'cablecast_vod_embed', true);
+                    if ($video_iframe) {
+                        echo '<div class="embed-responsive">' . $video_iframe . '</div>';
+                    }
+                } else {
+                    $thumbnail_url = get_the_post_thumbnail_url($post_id, 'full');
+                    if ($thumbnail_url) {
+                        echo '<div class="relative">';
+                        echo '<img src="' . esc_url($thumbnail_url) . '" alt="' . esc_attr(get_the_title()) . '" class="attachment-post-thumbnail size-post-thumbnail wp-post-image">';
+                        // Overlay for restricted content
+                        echo '
+                            <div class="absolute bottom-0 left-0 right-0 bg-black bg-opacity-50 text-white text-center py-10">
+                                <div class="flex justify-center flex-col gap-y-2">
+                                    <span>This Content requires a membership to view.</span>
+                                    <span>Login or register below.</span>
+                                    <div class="mt-4">
+                                        <a href="/login" class="btn secondary-button hover:shadow text-white  py-2 px-4 ">Login</a>
+                                        <a href="/register" class="btn secondary-button hover:shadow text-white  py-2 px-4 ">Register</a>
+                                    </div>
+                                </div>  
+                            </div>';
+                        echo '</div>';
+                    }
+                }
+?>

--- a/theme/template-parts/layout/footer-content.php
+++ b/theme/template-parts/layout/footer-content.php
@@ -9,7 +9,7 @@
 
 ?>
 
-<footer class="bg-brand-secondary relative w-full  py-8 px-2">
+<footer class="banner relative w-full  py-8 px-2">
     <div id="bottombar-container"> <!-- site navigation -->
         <nav id=" site-navigation" aria-label="<?php esc_attr_e( 'Main Navigation', 'cablecast' ); ?>">
             <button class="hidden" aria-controls="primary-menu"
@@ -106,12 +106,31 @@
 
         <div class="text-white text-center mt-4">
             <?php
-                        // Output the footer widget area
-                        if ( is_active_sidebar( 'sidebar-1' ) ) {
-                            dynamic_sidebar( 'sidebar-1' );
-                        }
-                        ?>
+            // Output the footer social media widget area
+            if ( is_active_sidebar( 'sidebar-1' ) ) {
+                dynamic_sidebar( 'sidebar-1' );
+            }
+            ?>
         </div>
+
+        <?php
+            // Retrieve the Contact info settings
+            $contact_info = get_option('contact_info_settings');
+        ?>
+
+        <div class="footer-contact-info-container text-center text-white">
+        <?php
+            if ($contact_info['email']) {
+                echo '<div><a href="mailto:' . esc_html($contact_info['email']) . '" class="hover:underline" target="_blank">' . esc_html($contact_info['email']) . '</a>';
+            }
+            if ($contact_info['phonenumber']) {
+                echo ' | <a href="tel:' . esc_html($contact_info['phonenumber']) . '" class="hover:underline" target="_blank">' . esc_html($contact_info['phonenumber']) . '</a></div>';
+            }
+            if ($contact_info['address']) {
+                echo '<div class="pb-5"><a href="https://www.google.com/maps/search/?api=1&query=' . urlencode($contact_info['address']) . '" class="hover:underline" target="_blank">' . esc_html($contact_info['address']) . '</a></div>';
+            }?>
+        </div>
+
         <div class="footer-copyright"> Copyright &copy; <? the_date('Y') ?> Tightrope Media Systems</div>
     </div>
 


### PR DESCRIPTION
Added areas to the show page for agenda and chapters. I put the details information, chapters and agenda all into their own template parts files to keep things organized and easy to work with. Agenda is just an embed to a pdf asset. When the screen is mobile, the agenda on the left is hidden and the agenda in a tab is made visible. The chapters is an unordered list with list items for the times and chapter links, set up to be a two column grid. Added in the program description so that shows now. Added two buttons for downloading the agenda or the video, since I noticed we had those in two video pages on the local site. I can add more buttons or reformat those if there are other download things that need to be accounted for.

<img width="1254" alt="Screenshot 2024-07-25 at 3 19 54 PM" src="https://github.com/user-attachments/assets/97f0fb43-9771-4457-ab5b-029d3a32ae90">
<img width="1271" alt="Screenshot 2024-07-25 at 3 20 04 PM" src="https://github.com/user-attachments/assets/277929ef-c182-442c-87db-88d19cab31c5">
